### PR TITLE
Link stories in playbook

### DIFF
--- a/customtypes/playbook/index.json
+++ b/customtypes/playbook/index.json
@@ -75,6 +75,14 @@
           "select": null
         }
       },
+      "story": {
+        "type": "Link",
+        "config": {
+          "label": "Story",
+          "select": "document",
+          "customtypes": ["story"]
+        }
+      },
       "slices": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1086,6 +1086,17 @@ interface PlaybookDocumentData {
   audio: prismic.LinkField;
 
   /**
+   * Story field in *Playbook*
+   *
+   * - **Field Type**: Content Relationship
+   * - **Placeholder**: *None*
+   * - **API ID Path**: playbook.story
+   * - **Tab**: Main
+   * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+   */
+  story: prismic.ContentRelationshipField<"story">;
+
+  /**
    * Slice Zone field in *Playbook*
    *
    * - **Field Type**: Slice Zone

--- a/src/components/playbook/viewer/List.tsx
+++ b/src/components/playbook/viewer/List.tsx
@@ -12,7 +12,7 @@ export default function List({ data }: { data: Content.PlaybookDocumentData }) {
         destination={data.destination as unknown as Content.DestinationDocument}
       />
 
-      <ListContent description={data.description} audio={data.audio} slices={data.slices} creator={data.creator} />
+      <ListContent description={data.description} audio={data.audio} slices={data.slices} creator={data.creator} story={data.story} />
     </div>
   );
 }

--- a/src/components/playbook/viewer/list/ListContent.tsx
+++ b/src/components/playbook/viewer/list/ListContent.tsx
@@ -16,6 +16,7 @@ interface ListContentProps {
   audio: LinkField;
   slices: SliceZoneType<Content.GemSlice>;
   creator: ContentRelationshipField<"creator">;
+  story: ContentRelationshipField<"story">;
 }
 
 export default function ListContent(props: ListContentProps) {
@@ -23,7 +24,7 @@ export default function ListContent(props: ListContentProps) {
 
   return (
     <div className="grid m-3 md:m-4 my-5 md:my-6 gap-y-10 md:gap-y-12">
-      <Details description={props.description} audio={audioFile} />
+      <Details description={props.description} audio={audioFile} story={props.story} />
       <SliceZone slices={props.slices} components={components} context={{ creator: props.creator }} />
     </div>
   );

--- a/src/components/playbook/viewer/list/list-content/Details.tsx
+++ b/src/components/playbook/viewer/list/list-content/Details.tsx
@@ -1,22 +1,22 @@
 import Link from "next/link";
 import { PrismicRichText } from "@prismicio/react";
-import { RichTextField } from "@prismicio/client";
+import {ContentRelationshipField, RichTextField} from "@prismicio/client";
 import Audio from "./details/Audio";
 import Story from "@/img/icon-story.svg";
 
-export default function ListContent({ description, audio }: { description: RichTextField; audio: string }) {
+export default function ListContent({ description, audio, story }: { description: RichTextField; audio: string, story: ContentRelationshipField<"story"> }) {
   return (
     <section className="grid gap-y-5 md:gap-y-6 [&>p]:text-base [&>p]:text-ex-grey">
       {description.length !== 0 && <PrismicRichText field={description} />}
       {audio && <Audio file={audio} />}
-
-      <Link
-        href="/"
-        className="text-ex-blue hover:bg-ex-blue hover:text-white duration-300 ease-in-out transition-[background-color,color] rounded-full p-2 pl-4 pr-4 border border-ex-blue flex items-center justify-center md:w-max"
-      >
-        <Story className="h-5 w-5 inline mr-2" />
-        Read the Interview
-      </Link>
+      {'uid' in story &&
+          <Link
+              href={`/stories/${story.uid}`}
+              className="text-ex-blue hover:bg-ex-blue hover:text-white duration-300 ease-in-out transition-[background-color,color] rounded-full p-2 pl-4 pr-4 border border-ex-blue flex items-center justify-center md:w-max"
+          >
+              <Story className="h-5 w-5 inline mr-2" />
+              Read the Interview
+          </Link> }
     </section>
   );
 }


### PR DESCRIPTION
- Link stories in the playbook
- Display read the interview only if a story is linked
- Preserve 'stories/:slug' pattern from the old website