### PR TITLE
Add stories

### DIFF
--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -51,6 +51,9 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
+            "story_text_with_heading": {
+              "type": "SharedSlice"
+            },
             "story_text_block": {
               "type": "SharedSlice"
             },

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -51,6 +51,9 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
+            "story_text_block": {
+              "type": "SharedSlice"
+            },
             "story_highlight": {
               "type": "SharedSlice"
             }

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -50,7 +50,11 @@
         "type": "Slices",
         "fieldset": "Slice Zone",
         "config": {
-          "choices": {}
+          "choices": {
+            "story_highlight": {
+              "type": "SharedSlice"
+            }
+          }
         }
       }
     },

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -19,6 +19,13 @@
           "placeholder": ""
         }
       },
+      "feature": {
+        "type": "Text",
+        "config": {
+          "label": "Feature",
+          "placeholder": ""
+        }
+      },
       "creator": {
         "type": "Link",
         "config": {

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -39,7 +39,10 @@
         "type": "Image",
         "config": {
           "label": "Image",
-          "constraint": {},
+          "constraint": {
+            "width": 1200,
+            "height": 900
+          },
           "thumbnails": []
         }
       },

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -46,6 +46,14 @@
           "thumbnails": []
         }
       },
+      "playbook": {
+        "type": "Link",
+        "config": {
+          "label": "Playbook",
+          "select": "document",
+          "customtypes": ["playbook"]
+        }
+      },
       "slices": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -66,6 +66,9 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
+            "story_gems": {
+              "type": "SharedSlice"
+            },
             "story_gallery": {
               "type": "SharedSlice"
             },

--- a/customtypes/story/index.json
+++ b/customtypes/story/index.json
@@ -51,6 +51,9 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
+            "story_gallery": {
+              "type": "SharedSlice"
+            },
             "story_text_with_heading": {
               "type": "SharedSlice"
             },

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1378,6 +1378,17 @@ interface StoryDocumentData {
   title: prismic.KeyTextField;
 
   /**
+   * Feature field in *Story*
+   *
+   * - **Field Type**: Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story.feature
+   * - **Tab**: Main
+   * - **Documentation**: https://prismic.io/docs/field#key-text
+   */
+  feature: prismic.KeyTextField;
+
+  /**
    * Creator field in *Story*
    *
    * - **Field Type**: Content Relationship

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1837,6 +1837,48 @@ type StoryGallerySliceVariation = StoryGallerySliceDefault;
 export type StoryGallerySlice = prismic.SharedSlice<"story_gallery", StoryGallerySliceVariation>;
 
 /**
+ * Primary content in *StoryGems → Items*
+ */
+export interface StoryGemsSliceDefaultItem {
+  /**
+   * Gem field in *StoryGems → Items*
+   *
+   * - **Field Type**: Content Relationship
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_gems.items[].gem
+   * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+   */
+  gem: prismic.ContentRelationshipField<"gem">;
+}
+
+/**
+ * Default variation for StoryGems Slice
+ *
+ * - **API ID**: `default`
+ * - **Description**: Default
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryGemsSliceDefault = prismic.SharedSliceVariation<
+  "default",
+  Record<string, never>,
+  Simplify<StoryGemsSliceDefaultItem>
+>;
+
+/**
+ * Slice variation for *StoryGems*
+ */
+type StoryGemsSliceVariation = StoryGemsSliceDefault;
+
+/**
+ * StoryGems Shared Slice
+ *
+ * - **API ID**: `story_gems`
+ * - **Description**: StoryGems
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryGemsSlice = prismic.SharedSlice<"story_gems", StoryGemsSliceVariation>;
+
+/**
  * Primary content in *StoryHighlight → Primary*
  */
 export interface StoryHighlightSliceDefaultPrimary {
@@ -2225,6 +2267,10 @@ declare module "@prismicio/client" {
       StoryGallerySliceDefaultItem,
       StoryGallerySliceVariation,
       StoryGallerySliceDefault,
+      StoryGemsSlice,
+      StoryGemsSliceDefaultItem,
+      StoryGemsSliceVariation,
+      StoryGemsSliceDefault,
       StoryHighlightSlice,
       StoryHighlightSliceDefaultPrimary,
       StoryHighlightSliceVariation,

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1356,7 +1356,11 @@ export type SearchDocument<Lang extends string = string> = prismic.PrismicDocume
   Lang
 >;
 
-type StoryDocumentDataSlicesSlice = StoryTextWithHeadingSlice | StoryTextBlockSlice | StoryHighlightSlice;
+type StoryDocumentDataSlicesSlice =
+  | StoryGallerySlice
+  | StoryTextWithHeadingSlice
+  | StoryTextBlockSlice
+  | StoryHighlightSlice;
 
 /**
  * Content for Story documents
@@ -1765,6 +1769,48 @@ type SingleHeadingSliceVariation = SingleHeadingSliceDefault;
 export type SingleHeadingSlice = prismic.SharedSlice<"single_heading", SingleHeadingSliceVariation>;
 
 /**
+ * Primary content in *StoryGallery → Items*
+ */
+export interface StoryGallerySliceDefaultItem {
+  /**
+   * Image field in *StoryGallery → Items*
+   *
+   * - **Field Type**: Image
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_gallery.items[].image
+   * - **Documentation**: https://prismic.io/docs/field#image
+   */
+  image: prismic.ImageField<never>;
+}
+
+/**
+ * Default variation for StoryGallery Slice
+ *
+ * - **API ID**: `default`
+ * - **Description**: Default
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryGallerySliceDefault = prismic.SharedSliceVariation<
+  "default",
+  Record<string, never>,
+  Simplify<StoryGallerySliceDefaultItem>
+>;
+
+/**
+ * Slice variation for *StoryGallery*
+ */
+type StoryGallerySliceVariation = StoryGallerySliceDefault;
+
+/**
+ * StoryGallery Shared Slice
+ *
+ * - **API ID**: `story_gallery`
+ * - **Description**: StoryGallery
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryGallerySlice = prismic.SharedSlice<"story_gallery", StoryGallerySliceVariation>;
+
+/**
  * Primary content in *StoryHighlight → Primary*
  */
 export interface StoryHighlightSliceDefaultPrimary {
@@ -2148,6 +2194,10 @@ declare module "@prismicio/client" {
       SingleHeadingSliceDefaultPrimary,
       SingleHeadingSliceVariation,
       SingleHeadingSliceDefault,
+      StoryGallerySlice,
+      StoryGallerySliceDefaultItem,
+      StoryGallerySliceVariation,
+      StoryGallerySliceDefault,
       StoryHighlightSlice,
       StoryHighlightSliceDefaultPrimary,
       StoryHighlightSliceVariation,

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1357,6 +1357,7 @@ export type SearchDocument<Lang extends string = string> = prismic.PrismicDocume
 >;
 
 type StoryDocumentDataSlicesSlice =
+  | StoryGemsSlice
   | StoryGallerySlice
   | StoryTextWithHeadingSlice
   | StoryTextBlockSlice
@@ -1848,6 +1849,21 @@ type StoryGallerySliceVariation = StoryGallerySliceDefault;
 export type StoryGallerySlice = prismic.SharedSlice<"story_gallery", StoryGallerySliceVariation>;
 
 /**
+ * Primary content in *StoryGems → Primary*
+ */
+export interface StoryGemsSliceDefaultPrimary {
+  /**
+   * Creator field in *StoryGems → Primary*
+   *
+   * - **Field Type**: Content Relationship
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_gems.primary.creator
+   * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+   */
+  creator: prismic.ContentRelationshipField<"creator">;
+}
+
+/**
  * Primary content in *StoryGems → Items*
  */
 export interface StoryGemsSliceDefaultItem {
@@ -1871,7 +1887,7 @@ export interface StoryGemsSliceDefaultItem {
  */
 export type StoryGemsSliceDefault = prismic.SharedSliceVariation<
   "default",
-  Record<string, never>,
+  Simplify<StoryGemsSliceDefaultPrimary>,
   Simplify<StoryGemsSliceDefaultItem>
 >;
 
@@ -2279,6 +2295,7 @@ declare module "@prismicio/client" {
       StoryGallerySliceVariation,
       StoryGallerySliceDefault,
       StoryGemsSlice,
+      StoryGemsSliceDefaultPrimary,
       StoryGemsSliceDefaultItem,
       StoryGemsSliceVariation,
       StoryGemsSliceDefault,

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1411,6 +1411,17 @@ interface StoryDocumentData {
   image: prismic.ImageField<never>;
 
   /**
+   * Playbook field in *Story*
+   *
+   * - **Field Type**: Content Relationship
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story.playbook
+   * - **Tab**: Main
+   * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+   */
+  playbook: prismic.ContentRelationshipField<"playbook">;
+
+  /**
    * Slice Zone field in *Story*
    *
    * - **Field Type**: Slice Zone

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1356,7 +1356,7 @@ export type SearchDocument<Lang extends string = string> = prismic.PrismicDocume
   Lang
 >;
 
-type StoryDocumentDataSlicesSlice = StoryHighlightSlice;
+type StoryDocumentDataSlicesSlice = StoryTextBlockSlice | StoryHighlightSlice;
 
 /**
  * Content for Story documents
@@ -1807,6 +1807,48 @@ type StoryHighlightSliceVariation = StoryHighlightSliceDefault;
 export type StoryHighlightSlice = prismic.SharedSlice<"story_highlight", StoryHighlightSliceVariation>;
 
 /**
+ * Primary content in *StoryTextBlock → Primary*
+ */
+export interface StoryTextBlockSliceDefaultPrimary {
+  /**
+   * Text field in *StoryTextBlock → Primary*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_text_block.primary.text
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  text: prismic.RichTextField;
+}
+
+/**
+ * Default variation for StoryTextBlock Slice
+ *
+ * - **API ID**: `default`
+ * - **Description**: Default
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryTextBlockSliceDefault = prismic.SharedSliceVariation<
+  "default",
+  Simplify<StoryTextBlockSliceDefaultPrimary>,
+  never
+>;
+
+/**
+ * Slice variation for *StoryTextBlock*
+ */
+type StoryTextBlockSliceVariation = StoryTextBlockSliceDefault;
+
+/**
+ * StoryTextBlock Shared Slice
+ *
+ * - **API ID**: `story_text_block`
+ * - **Description**: StoryTextBlock
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryTextBlockSlice = prismic.SharedSlice<"story_text_block", StoryTextBlockSliceVariation>;
+
+/**
  * Primary content in *TextBlock → Primary*
  */
 export interface TextBlockSliceDefaultPrimary {
@@ -2055,6 +2097,10 @@ declare module "@prismicio/client" {
       StoryHighlightSliceDefaultPrimary,
       StoryHighlightSliceVariation,
       StoryHighlightSliceDefault,
+      StoryTextBlockSlice,
+      StoryTextBlockSliceDefaultPrimary,
+      StoryTextBlockSliceVariation,
+      StoryTextBlockSliceDefault,
       TextBlockSlice,
       TextBlockSliceDefaultPrimary,
       TextBlockSliceVariation,

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1356,7 +1356,7 @@ export type SearchDocument<Lang extends string = string> = prismic.PrismicDocume
   Lang
 >;
 
-type StoryDocumentDataSlicesSlice = never;
+type StoryDocumentDataSlicesSlice = StoryHighlightSlice;
 
 /**
  * Content for Story documents
@@ -1765,6 +1765,48 @@ type SingleHeadingSliceVariation = SingleHeadingSliceDefault;
 export type SingleHeadingSlice = prismic.SharedSlice<"single_heading", SingleHeadingSliceVariation>;
 
 /**
+ * Primary content in *StoryHighlight → Primary*
+ */
+export interface StoryHighlightSliceDefaultPrimary {
+  /**
+   * Text field in *StoryHighlight → Primary*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_highlight.primary.text
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  text: prismic.RichTextField;
+}
+
+/**
+ * Default variation for StoryHighlight Slice
+ *
+ * - **API ID**: `default`
+ * - **Description**: Default
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryHighlightSliceDefault = prismic.SharedSliceVariation<
+  "default",
+  Simplify<StoryHighlightSliceDefaultPrimary>,
+  never
+>;
+
+/**
+ * Slice variation for *StoryHighlight*
+ */
+type StoryHighlightSliceVariation = StoryHighlightSliceDefault;
+
+/**
+ * StoryHighlight Shared Slice
+ *
+ * - **API ID**: `story_highlight`
+ * - **Description**: StoryHighlight
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryHighlightSlice = prismic.SharedSlice<"story_highlight", StoryHighlightSliceVariation>;
+
+/**
  * Primary content in *TextBlock → Primary*
  */
 export interface TextBlockSliceDefaultPrimary {
@@ -2009,6 +2051,10 @@ declare module "@prismicio/client" {
       SingleHeadingSliceDefaultPrimary,
       SingleHeadingSliceVariation,
       SingleHeadingSliceDefault,
+      StoryHighlightSlice,
+      StoryHighlightSliceDefaultPrimary,
+      StoryHighlightSliceVariation,
+      StoryHighlightSliceDefault,
       TextBlockSlice,
       TextBlockSliceDefaultPrimary,
       TextBlockSliceVariation,

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1356,7 +1356,7 @@ export type SearchDocument<Lang extends string = string> = prismic.PrismicDocume
   Lang
 >;
 
-type StoryDocumentDataSlicesSlice = StoryTextBlockSlice | StoryHighlightSlice;
+type StoryDocumentDataSlicesSlice = StoryTextWithHeadingSlice | StoryTextBlockSlice | StoryHighlightSlice;
 
 /**
  * Content for Story documents
@@ -1849,6 +1849,61 @@ type StoryTextBlockSliceVariation = StoryTextBlockSliceDefault;
 export type StoryTextBlockSlice = prismic.SharedSlice<"story_text_block", StoryTextBlockSliceVariation>;
 
 /**
+ * Primary content in *StoryTextWithHeading → Primary*
+ */
+export interface StoryTextWithHeadingSliceDefaultPrimary {
+  /**
+   * Heading field in *StoryTextWithHeading → Primary*
+   *
+   * - **Field Type**: Title
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_text_with_heading.primary.heading
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  heading: prismic.TitleField;
+
+  /**
+   * Text field in *StoryTextWithHeading → Primary*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_text_with_heading.primary.text
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  text: prismic.RichTextField;
+}
+
+/**
+ * Default variation for StoryTextWithHeading Slice
+ *
+ * - **API ID**: `default`
+ * - **Description**: Default
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryTextWithHeadingSliceDefault = prismic.SharedSliceVariation<
+  "default",
+  Simplify<StoryTextWithHeadingSliceDefaultPrimary>,
+  never
+>;
+
+/**
+ * Slice variation for *StoryTextWithHeading*
+ */
+type StoryTextWithHeadingSliceVariation = StoryTextWithHeadingSliceDefault;
+
+/**
+ * StoryTextWithHeading Shared Slice
+ *
+ * - **API ID**: `story_text_with_heading`
+ * - **Description**: StoryTextWithHeading
+ * - **Documentation**: https://prismic.io/docs/slice
+ */
+export type StoryTextWithHeadingSlice = prismic.SharedSlice<
+  "story_text_with_heading",
+  StoryTextWithHeadingSliceVariation
+>;
+
+/**
  * Primary content in *TextBlock → Primary*
  */
 export interface TextBlockSliceDefaultPrimary {
@@ -2101,6 +2156,10 @@ declare module "@prismicio/client" {
       StoryTextBlockSliceDefaultPrimary,
       StoryTextBlockSliceVariation,
       StoryTextBlockSliceDefault,
+      StoryTextWithHeadingSlice,
+      StoryTextWithHeadingSliceDefaultPrimary,
+      StoryTextWithHeadingSliceVariation,
+      StoryTextWithHeadingSliceDefault,
       TextBlockSlice,
       TextBlockSliceDefaultPrimary,
       TextBlockSliceVariation,

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1769,6 +1769,21 @@ type SingleHeadingSliceVariation = SingleHeadingSliceDefault;
 export type SingleHeadingSlice = prismic.SharedSlice<"single_heading", SingleHeadingSliceVariation>;
 
 /**
+ * Primary content in *StoryGallery → Primary*
+ */
+export interface StoryGallerySliceDefaultPrimary {
+  /**
+   * Caption field in *StoryGallery → Primary*
+   *
+   * - **Field Type**: Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: story_gallery.primary.caption
+   * - **Documentation**: https://prismic.io/docs/field#key-text
+   */
+  caption: prismic.KeyTextField;
+}
+
+/**
  * Primary content in *StoryGallery → Items*
  */
 export interface StoryGallerySliceDefaultItem {
@@ -1792,7 +1807,7 @@ export interface StoryGallerySliceDefaultItem {
  */
 export type StoryGallerySliceDefault = prismic.SharedSliceVariation<
   "default",
-  Record<string, never>,
+  Simplify<StoryGallerySliceDefaultPrimary>,
   Simplify<StoryGallerySliceDefaultItem>
 >;
 
@@ -2195,6 +2210,7 @@ declare module "@prismicio/client" {
       SingleHeadingSliceVariation,
       SingleHeadingSliceDefault,
       StoryGallerySlice,
+      StoryGallerySliceDefaultPrimary,
       StoryGallerySliceDefaultItem,
       StoryGallerySliceVariation,
       StoryGallerySliceDefault,

--- a/src/components/story/Header.tsx
+++ b/src/components/story/Header.tsx
@@ -8,7 +8,7 @@ interface HeaderProps {
 
 export default function Header(props: HeaderProps) {
   return(
-    <div>
+    <div className="relative">
       <Hero image={props.data.image} />
       <Overview data={props.data} />
     </div>

--- a/src/components/story/Header.tsx
+++ b/src/components/story/Header.tsx
@@ -1,5 +1,6 @@
 import { Content, ImageField } from "@prismicio/client";
 import Hero from "@/components/story/header/Hero";
+import Overview from "@/components/story/header/Overview";
 
 interface HeaderProps {
   data: Content.StoryDocumentData;
@@ -9,6 +10,7 @@ export default function Header(props: HeaderProps) {
   return(
     <div>
       <Hero image={props.data.image} />
+      <Overview data={props.data} />
     </div>
   );
 }

--- a/src/components/story/Header.tsx
+++ b/src/components/story/Header.tsx
@@ -1,0 +1,14 @@
+import { Content, ImageField } from "@prismicio/client";
+import Hero from "@/components/story/header/Hero";
+
+interface HeaderProps {
+  data: Content.StoryDocumentData;
+}
+
+export default function Header(props: HeaderProps) {
+  return(
+    <div>
+      <Hero image={props.data.image} />
+    </div>
+  );
+}

--- a/src/components/story/Share.tsx
+++ b/src/components/story/Share.tsx
@@ -1,21 +1,31 @@
-import Hero from "@/components/story/header/Hero";
-import Overview from "@/components/story/header/Overview";
 import { Content } from "@prismicio/client";
+import Playbook from "@/img/icon-playbook.svg";
+import Linkedin from "@/img/social-li.svg";
+import Facebook from "@/img/social-fb.svg";
 
 interface ShareProps {
   data: Content.StoryDocumentData;
 }
 
 export default function Share(props: ShareProps) {
+  const playbookUrl = `https://exceptionalalien.com/travel-playbooks/${ (props.data.playbook as unknown as Content.PlaybookDocument).uid }`;
+
   return(
-    <div>
-      <p>Explore Playbook</p>
-      <a></a>
-      <p>Share</p>
-      <a></a>
-      <a></a>
-      <a></a>
-      <a></a>
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="fixed right-0 top-1/2 transform -translate-y-1/2">
+        <p className="block">Explore</p>
+        <p className="block">Playbook</p>
+        <a href={ playbookUrl } target={"_blank"}>
+          <Playbook className="mb-1 mr-1 h-5 overflow-visible md:mr-2 md:h-6" />
+        </a>
+        <p className="block">Share</p>
+        <a href={ `https://www.linkedin.com/shareArticle?mini=true&url=${ playbookUrl }` } target={"_blank"}>
+          <Linkedin className="mb-1 mr-1 h-5 overflow-visible md:mr-2 md:h-6" />
+        </a>
+        <a href={ `https://www.facebook.com/sharer/sharer.php?u=${ playbookUrl }` } target={"_blank"}>
+          <Facebook className="mb-1 mr-1 h-5 overflow-visible md:mr-2 md:h-6" />
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/components/story/Share.tsx
+++ b/src/components/story/Share.tsx
@@ -1,0 +1,21 @@
+import Hero from "@/components/story/header/Hero";
+import Overview from "@/components/story/header/Overview";
+import { Content } from "@prismicio/client";
+
+interface ShareProps {
+  data: Content.StoryDocumentData;
+}
+
+export default function Share(props: ShareProps) {
+  return(
+    <div>
+      <p>Explore Playbook</p>
+      <a></a>
+      <p>Share</p>
+      <a></a>
+      <a></a>
+      <a></a>
+      <a></a>
+    </div>
+  );
+}

--- a/src/components/story/header/Hero.tsx
+++ b/src/components/story/header/Hero.tsx
@@ -7,7 +7,7 @@ interface HeroProps {
 export default function Hero(props: HeroProps) {
   return(
     <div>
-      <PrismicNextImage className="w-full" field={props.image} />
+      <PrismicNextImage className="w-full" field={props.image} alt="" />
     </div>
   );
 }

--- a/src/components/story/header/Hero.tsx
+++ b/src/components/story/header/Hero.tsx
@@ -6,8 +6,6 @@ interface HeroProps {
 }
 export default function Hero(props: HeroProps) {
   return(
-    <div>
-      <PrismicNextImage className="w-full" field={props.image} alt="" />
-    </div>
+    <PrismicNextImage className="w-full" field={props.image} alt="" />
   );
 }

--- a/src/components/story/header/Hero.tsx
+++ b/src/components/story/header/Hero.tsx
@@ -1,0 +1,13 @@
+import { ImageField } from "@prismicio/client";
+import { PrismicNextImage } from "@prismicio/next";
+
+interface HeroProps {
+  image: ImageField;
+}
+export default function Hero(props: HeroProps) {
+  return(
+    <div>
+      <PrismicNextImage className="w-full" field={props.image} />
+    </div>
+  );
+}

--- a/src/components/story/header/Overview.tsx
+++ b/src/components/story/header/Overview.tsx
@@ -7,9 +7,9 @@ interface OverviewProps {
 }
 export default function Overview(props: OverviewProps) {
   return(
-    <div>
-      <h2>{ props.data.title }</h2>
-      <div>
+    <div className="relative m-auto md:max-w-3xl md:text-4xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl [&>p]:mt-4 [&>p]:md:mt-6">
+      <h2 className="text-2xl text-center font-bold text-black">{ props.data.title }</h2>
+      <div className="bg-ex-blue p-5">
         <CreatorIcon
           firstName={(props.data.creator as unknown as Content.CreatorDocument).data.first_name as string}
           lastName={(props.data.creator as unknown as Content.CreatorDocument).data.last_name as string}

--- a/src/components/story/header/Overview.tsx
+++ b/src/components/story/header/Overview.tsx
@@ -1,0 +1,29 @@
+import { Content } from "@prismicio/client";
+import CreatorIcon from "@/components/shared/CreatorIcon";
+import CreatorThumb from "@/components/shared/CreatorThumb";
+
+interface OverviewProps {
+  data: Content.StoryDocumentData;
+}
+export default function Overview(props: OverviewProps) {
+  return(
+    <div>
+      <h2>{ props.data.title }</h2>
+      <div>
+        <div>
+          <p>
+            Gems in this story
+            <span>
+              {'gems'}
+            </span>
+          </p>
+        </div>
+        <CreatorIcon
+          firstName={(props.data.creator as unknown as Content.CreatorDocument).data.first_name as string}
+          lastName={(props.data.creator as unknown as Content.CreatorDocument).data.last_name as string}
+          image={(props.data.creator as unknown as Content.CreatorDocument).data.profile_image}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/story/header/Overview.tsx
+++ b/src/components/story/header/Overview.tsx
@@ -10,14 +10,6 @@ export default function Overview(props: OverviewProps) {
     <div>
       <h2>{ props.data.title }</h2>
       <div>
-        <div>
-          <p>
-            Gems in this story
-            <span>
-              {'gems'}
-            </span>
-          </p>
-        </div>
         <CreatorIcon
           firstName={(props.data.creator as unknown as Content.CreatorDocument).data.first_name as string}
           lastName={(props.data.creator as unknown as Content.CreatorDocument).data.last_name as string}

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -73,7 +73,7 @@ export async function getStaticProps({ params, previewData }: GetStaticPropsCont
     const client = createClient({ previewData });
 
     const page = await client.getByUID("story", params?.uid as string, {
-      fetchLinks: "playbook.title,playbook.image,playbook.destination,playbook.creator,creator.first_name,creator.last_name,creator.profile_image,destination.title",
+      fetchLinks: "playbook.title,playbook.image,playbook.destination,playbook.creator,creator.first_name,creator.last_name,creator.profile_image,destination.title,gem.image,gem.title,gem.category",
     });
 
     return {

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -1,0 +1,8 @@
+import { GetStaticPaths } from "next";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -56,6 +56,7 @@ export default function Story({ page }: PageProps) {
             showDestination={true}
           />
         </div>
+        <Share data={page.data}/>
       </main>
     </>
   );

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -3,6 +3,8 @@ import { createClient } from "@/prismicio";
 import Head from "next/head";
 import { SliceZone } from "@prismicio/react";
 import { components } from "@/slices";
+import PlaybookThumb from "@/components/shared/PlaybookThumb";
+import { Content } from "@prismicio/client";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
@@ -42,6 +44,14 @@ export default function Story({ page }: PageProps) {
       </Head>
       <main>
         <SliceZone slices={page.data.slices} components={components} />
+        <div className="grid grid-cols-2 gap-x-2 gap-y-4 md:gap-x-3 md:gap-y-6 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" >
+          <PlaybookThumb
+            playbook={page.data.playbook as unknown as Content.PlaybookDocument}
+            size="med"
+            showCreator={true}
+            showDestination={true}
+          />
+        </div>
       </main>
     </>
   );
@@ -58,7 +68,9 @@ export async function getStaticProps({ params, previewData }: GetStaticPropsCont
   try {
     const client = createClient({ previewData });
 
-    const page = await client.getByUID("story", params?.uid as string);
+    const page = await client.getByUID("story", params?.uid as string, {
+      fetchLinks: "playbook.title,playbook.image,playbook.destination,playbook.creator,creator.first_name,creator.last_name,creator.profile_image,destination.title",
+    });
 
     return {
       props: {

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -38,6 +38,9 @@ export default function Story({ page }: PageProps) {
           }
         />
       </Head>
+      <main>
+
+      </main>
     </>
   );
 }

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -1,6 +1,8 @@
 import { GetStaticPaths, GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { createClient } from "@/prismicio";
 import Head from "next/head";
+import { SliceZone } from "@prismicio/react";
+import { components } from "@/slices";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
@@ -39,7 +41,7 @@ export default function Story({ page }: PageProps) {
         />
       </Head>
       <main>
-
+        <SliceZone slices={page.data.slices} components={components} />
       </main>
     </>
   );

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -45,6 +45,7 @@ export default function Story({ page }: PageProps) {
       </Head>
       <main>
         <Header data={page.data} />
+        <div>Feature by <span>{page.data.feature}</span></div>
         <SliceZone slices={page.data.slices} components={components} />
         <div className="grid grid-cols-2 gap-x-2 gap-y-4 md:gap-x-3 md:gap-y-6 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" >
           <PlaybookThumb

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -5,6 +5,7 @@ import { SliceZone } from "@prismicio/react";
 import { components } from "@/slices";
 import PlaybookThumb from "@/components/shared/PlaybookThumb";
 import { Content } from "@prismicio/client";
+import Header from "@/components/story/Header";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
@@ -43,6 +44,7 @@ export default function Story({ page }: PageProps) {
         />
       </Head>
       <main>
+        <Header data={page.data} />
         <SliceZone slices={page.data.slices} components={components} />
         <div className="grid grid-cols-2 gap-x-2 gap-y-4 md:gap-x-3 md:gap-y-6 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" >
           <PlaybookThumb

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -1,4 +1,14 @@
-import { GetStaticPaths } from "next";
+import { GetStaticPaths, GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import { createClient } from "@/prismicio";
+
+type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
+
+export default function Story({ page }: PageProps) {
+  return (
+    <>
+    </>
+  );
+}
 
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
@@ -6,3 +16,19 @@ export const getStaticPaths: GetStaticPaths = async () => {
     fallback: "blocking",
   };
 };
+
+export async function getStaticProps({ params, previewData }: GetStaticPropsContext) {
+  try {
+    const client = createClient({ previewData });
+
+    const page = await client.getByUID("story", params?.uid as string);
+
+    return {
+      props: {
+        page,
+      },
+    };
+  } catch (error) {
+    return { notFound: true };
+  }
+}

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -48,7 +48,7 @@ export default function Story({ page }: PageProps) {
         <Header data={page.data} />
         <div className="m-auto text-center mt-10 mb-10 text-ex-grey text-xs">Feature by <span className="text-black">{page.data.feature}</span></div>
         <SliceZone slices={page.data.slices} components={components} />
-        <div className="grid grid-cols-2 gap-x-2 gap-y-4 md:gap-x-3 md:gap-y-6 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" >
+        <div className="m-auto grid grid-cols-2 gap-x-2 gap-y-4 md:gap-x-3 md:gap-y-6 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" >
           <PlaybookThumb
             playbook={page.data.playbook as unknown as Content.PlaybookDocument}
             size="med"

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -46,7 +46,7 @@ export default function Story({ page }: PageProps) {
       </Head>
       <main>
         <Header data={page.data} />
-        <div>Feature by <span>{page.data.feature}</span></div>
+        <div className="m-auto text-center mt-10 mb-10 text-ex-grey text-xs">Feature by <span className="text-black">{page.data.feature}</span></div>
         <SliceZone slices={page.data.slices} components={components} />
         <div className="grid grid-cols-2 gap-x-2 gap-y-4 md:gap-x-3 md:gap-y-6 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5" >
           <PlaybookThumb

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -1,11 +1,43 @@
 import { GetStaticPaths, GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { createClient } from "@/prismicio";
+import Head from "next/head";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 export default function Story({ page }: PageProps) {
   return (
     <>
+      <Head>
+        <title>{`${page.data.meta_title ? page.data.meta_title : page.data.title} | Exceptional ALIEN`}</title>
+
+        <meta
+          name="description"
+          content={page.data.meta_description ? page.data.meta_description : page.data.title as string}
+        />
+
+        <meta property="og:url" content={`https://exceptionalalien.com/stories/${page.uid}`} />
+
+        <meta
+          property="og:title"
+          content={`${page.data.meta_title ? page.data.meta_title : page.data.title} | Exceptional ALIEN`}
+        />
+
+        <meta
+          property="og:description"
+          content={page.data.meta_description ? page.data.meta_description : page.data.title as string}
+        />
+
+        <meta
+          property="og:image"
+          content={
+            page.data.meta_image.url
+              ? page.data.meta_image.url
+              : page.data.image.url
+                ? page.data.image.url
+                : "https://exceptionalalien.com/img/og.png"
+          }
+        />
+      </Head>
     </>
   );
 }

--- a/src/pages/stories/[uid].tsx
+++ b/src/pages/stories/[uid].tsx
@@ -6,6 +6,7 @@ import { components } from "@/slices";
 import PlaybookThumb from "@/components/shared/PlaybookThumb";
 import { Content } from "@prismicio/client";
 import Header from "@/components/story/Header";
+import Share from "@/components/story/Share";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 

--- a/src/slices/StoryGallery/index.tsx
+++ b/src/slices/StoryGallery/index.tsx
@@ -15,8 +15,8 @@ const StoryGallery = ({ slice }: StoryGalleryProps): JSX.Element => {
     <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         {slice.items.map((item, i) => (
-          <div>
-            <PrismicNextImage className="h-80 max-w-full rounded-lg" key={i} field={item.image} alt="" />
+          <div key={i}>
+            <PrismicNextImage className="h-80 max-w-full rounded-lg" field={item.image} alt="" />
           </div>
         ))}
       </div>

--- a/src/slices/StoryGallery/index.tsx
+++ b/src/slices/StoryGallery/index.tsx
@@ -1,0 +1,20 @@
+import { Content } from "@prismicio/client";
+import { SliceComponentProps } from "@prismicio/react";
+
+/**
+ * Props for `StoryGallery`.
+ */
+export type StoryGalleryProps = SliceComponentProps<Content.StoryGallerySlice>;
+
+/**
+ * Component for "StoryGallery" Slices.
+ */
+const StoryGallery = ({ slice }: StoryGalleryProps): JSX.Element => {
+  return (
+    <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+      Placeholder component for story_gallery (variation: {slice.variation}) Slices
+    </section>
+  );
+};
+
+export default StoryGallery;

--- a/src/slices/StoryGallery/index.tsx
+++ b/src/slices/StoryGallery/index.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
+import { PrismicNextImage } from "@prismicio/next";
 
 /**
  * Props for `StoryGallery`.
@@ -12,7 +13,16 @@ export type StoryGalleryProps = SliceComponentProps<Content.StoryGallerySlice>;
 const StoryGallery = ({ slice }: StoryGalleryProps): JSX.Element => {
   return (
     <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
-      Placeholder component for story_gallery (variation: {slice.variation}) Slices
+      <div>
+        {slice.items.map((item, i) => (
+          <div key={i}>
+            <PrismicNextImage field={item.image} alt="" />
+          </div>
+        ))}
+      </div>
+      <div>
+        {slice.primary.caption}
+      </div>
     </section>
   );
 };

--- a/src/slices/StoryGallery/index.tsx
+++ b/src/slices/StoryGallery/index.tsx
@@ -13,14 +13,15 @@ export type StoryGalleryProps = SliceComponentProps<Content.StoryGallerySlice>;
 const StoryGallery = ({ slice }: StoryGalleryProps): JSX.Element => {
   return (
     <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
-      <div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         {slice.items.map((item, i) => (
-          <div key={i}>
-            <PrismicNextImage field={item.image} alt="" />
+          <div>
+            <PrismicNextImage className="h-80 max-w-full rounded-lg" key={i} field={item.image} alt="" />
           </div>
         ))}
       </div>
-      <div>
+
+      <div className="m-auto text-center mt-10 mb-10 text-ex-grey text-xs">
         {slice.primary.caption}
       </div>
     </section>

--- a/src/slices/StoryGallery/mocks.json
+++ b/src/slices/StoryGallery/mocks.json
@@ -1,0 +1,38 @@
+[
+	{
+		"__TYPE__": "SharedSliceContent",
+		"variation": "default",
+		"primary": {},
+		"items": [
+			{
+				"__TYPE__": "GroupItemContent",
+				"value": [
+					[
+						"image",
+						{
+							"__TYPE__": "ImageContent",
+							"origin": {
+								"id": "main",
+								"url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
+								"width": 3882,
+								"height": 2584
+							},
+							"url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
+							"width": 3882,
+							"height": 2584,
+							"edit": {
+								"zoom": 1,
+								"crop": {
+									"x": 0,
+									"y": 0
+								},
+								"background": "transparent"
+							},
+							"thumbnails": {}
+						}
+					]
+				]
+			}
+		]
+	}
+]

--- a/src/slices/StoryGallery/mocks.json
+++ b/src/slices/StoryGallery/mocks.json
@@ -2,7 +2,13 @@
 	{
 		"__TYPE__": "SharedSliceContent",
 		"variation": "default",
-		"primary": {},
+		"primary": {
+			"caption": {
+				"__TYPE__": "FieldContent",
+				"value": "gulf",
+				"type": "Text"
+			}
+		},
 		"items": [
 			{
 				"__TYPE__": "GroupItemContent",
@@ -10,7 +16,6 @@
 					[
 						"image",
 						{
-							"__TYPE__": "ImageContent",
 							"origin": {
 								"id": "main",
 								"url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
@@ -28,6 +33,9 @@
 								},
 								"background": "transparent"
 							},
+							"credits": null,
+							"alt": null,
+							"__TYPE__": "ImageContent",
 							"thumbnails": {}
 						}
 					]

--- a/src/slices/StoryGallery/model.json
+++ b/src/slices/StoryGallery/model.json
@@ -11,7 +11,15 @@
       "version": "initial",
       "description": "Default",
       "imageUrl": "",
-      "primary": {},
+      "primary": {
+        "caption": {
+          "type": "Text",
+          "config": {
+            "label": "Caption",
+            "placeholder": ""
+          }
+        }
+      },
       "items": {
         "image": {
           "type": "Image",

--- a/src/slices/StoryGallery/model.json
+++ b/src/slices/StoryGallery/model.json
@@ -1,0 +1,27 @@
+{
+  "id": "story_gallery",
+  "type": "SharedSlice",
+  "name": "StoryGallery",
+  "description": "StoryGallery",
+  "variations": [
+    {
+      "id": "default",
+      "name": "Default",
+      "docURL": "...",
+      "version": "initial",
+      "description": "Default",
+      "imageUrl": "",
+      "primary": {},
+      "items": {
+        "image": {
+          "type": "Image",
+          "config": {
+            "label": "Image",
+            "constraint": {},
+            "thumbnails": []
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/slices/StoryGems/index.tsx
+++ b/src/slices/StoryGems/index.tsx
@@ -1,6 +1,6 @@
 import { Content } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
-import { PrismicNextImage } from "@prismicio/next";
+import GemThumb from "@/components/shared/GemThumb";
 
 /**
  * Props for `StoryGems`.
@@ -15,6 +15,7 @@ const StoryGems = ({ slice }: StoryGemsProps): JSX.Element => {
     <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
       {slice.items.map((item, i) => (
         <div key={i}>
+          <GemThumb gem={item.gem} />
         </div>
       ))}
     </section>

--- a/src/slices/StoryGems/index.tsx
+++ b/src/slices/StoryGems/index.tsx
@@ -12,7 +12,7 @@ export type StoryGemsProps = SliceComponentProps<Content.StoryGemsSlice>;
  */
 const StoryGems = ({ slice }: StoryGemsProps): JSX.Element => {
   return (
-    <section className="grid grid-cols-2 gap-x-2 gap-y-4 md:grid-cols-3 md:gap-x-3 md:gap-y-6 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+    <section className="mx-auto grid grid-cols-2 gap-x-2 gap-y-4 md:grid-cols-3 md:gap-x-3 md:gap-y-6 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-5" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
       {slice.items.map((item, i) => (
         <GemThumb
           key={i}

--- a/src/slices/StoryGems/index.tsx
+++ b/src/slices/StoryGems/index.tsx
@@ -1,0 +1,20 @@
+import { Content } from "@prismicio/client";
+import { SliceComponentProps } from "@prismicio/react";
+
+/**
+ * Props for `StoryGems`.
+ */
+export type StoryGemsProps = SliceComponentProps<Content.StoryGemsSlice>;
+
+/**
+ * Component for "StoryGems" Slices.
+ */
+const StoryGems = ({ slice }: StoryGemsProps): JSX.Element => {
+  return (
+    <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+      Placeholder component for story_gems (variation: {slice.variation}) Slices
+    </section>
+  );
+};
+
+export default StoryGems;

--- a/src/slices/StoryGems/index.tsx
+++ b/src/slices/StoryGems/index.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
+import { PrismicNextImage } from "@prismicio/next";
 
 /**
  * Props for `StoryGems`.
@@ -12,7 +13,10 @@ export type StoryGemsProps = SliceComponentProps<Content.StoryGemsSlice>;
 const StoryGems = ({ slice }: StoryGemsProps): JSX.Element => {
   return (
     <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
-      Placeholder component for story_gems (variation: {slice.variation}) Slices
+      {slice.items.map((item, i) => (
+        <div key={i}>
+        </div>
+      ))}
     </section>
   );
 };

--- a/src/slices/StoryGems/index.tsx
+++ b/src/slices/StoryGems/index.tsx
@@ -12,11 +12,16 @@ export type StoryGemsProps = SliceComponentProps<Content.StoryGemsSlice>;
  */
 const StoryGems = ({ slice }: StoryGemsProps): JSX.Element => {
   return (
-    <section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+    <section className="grid grid-cols-2 gap-x-2 gap-y-4 md:grid-cols-3 md:gap-x-3 md:gap-y-6 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
       {slice.items.map((item, i) => (
-        <div key={i}>
-          <GemThumb gem={item.gem} />
-        </div>
+        <GemThumb
+          key={i}
+          gem={item.gem as unknown as Content.GemDocument}
+          size="sml"
+          creator={
+            slice.primary.creator as unknown as Content.CreatorDocument
+          }
+        />
       ))}
     </section>
   );

--- a/src/slices/StoryGems/mocks.json
+++ b/src/slices/StoryGems/mocks.json
@@ -2,7 +2,15 @@
 	{
 		"__TYPE__": "SharedSliceContent",
 		"variation": "default",
-		"primary": {},
+		"primary": {
+			"creator": {
+				"__TYPE__": "LinkContent",
+				"value": {
+					"__TYPE__": "DocumentLink",
+					"id": "mock_document_id"
+				}
+			}
+		},
 		"items": [
 			{
 				"__TYPE__": "GroupItemContent",

--- a/src/slices/StoryGems/mocks.json
+++ b/src/slices/StoryGems/mocks.json
@@ -1,0 +1,24 @@
+[
+	{
+		"__TYPE__": "SharedSliceContent",
+		"variation": "default",
+		"primary": {},
+		"items": [
+			{
+				"__TYPE__": "GroupItemContent",
+				"value": [
+					[
+						"gem",
+						{
+							"__TYPE__": "LinkContent",
+							"value": {
+								"__TYPE__": "DocumentLink",
+								"id": "mock_document_id"
+							}
+						}
+					]
+				]
+			}
+		]
+	}
+]

--- a/src/slices/StoryGems/model.json
+++ b/src/slices/StoryGems/model.json
@@ -1,0 +1,29 @@
+{
+  "id": "story_gems",
+  "type": "SharedSlice",
+  "name": "StoryGems",
+  "description": "StoryGems",
+  "variations": [
+    {
+      "id": "default",
+      "name": "Default",
+      "docURL": "...",
+      "version": "initial",
+      "description": "Default",
+      "imageUrl": "",
+      "primary": {},
+      "items": {
+        "gem": {
+          "type": "Link",
+          "config": {
+            "label": "Gem",
+            "select": "document",
+            "customtypes": [
+              "gem"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/slices/StoryGems/model.json
+++ b/src/slices/StoryGems/model.json
@@ -11,7 +11,18 @@
       "version": "initial",
       "description": "Default",
       "imageUrl": "",
-      "primary": {},
+      "primary": {
+        "creator": {
+          "type": "Link",
+          "config": {
+            "label": "Creator",
+            "select": "document",
+            "customtypes": [
+              "creator"
+            ]
+          }
+        }
+      },
       "items": {
         "gem": {
           "type": "Link",

--- a/src/slices/StoryHighlight/index.tsx
+++ b/src/slices/StoryHighlight/index.tsx
@@ -11,7 +11,7 @@ export type StoryHighlightProps = SliceComponentProps<Content.StoryHighlightSlic
  */
 const StoryHighlight = ({ slice }: StoryHighlightProps): JSX.Element => {
   return (
-    <section className="" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+    <section className="m-auto text-2xl font-bold text-ex-blue md:max-w-3xl md:text-4xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl [&>p]:mt-4 [&>p]:md:mt-6" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
       <PrismicRichText field={slice.primary.text} />
     </section>
   );

--- a/src/slices/StoryHighlight/index.tsx
+++ b/src/slices/StoryHighlight/index.tsx
@@ -1,0 +1,20 @@
+import { Content } from "@prismicio/client";
+import { SliceComponentProps, PrismicRichText } from "@prismicio/react";
+
+/**
+ * Props for `StoryHighlight`.
+ */
+export type StoryHighlightProps = SliceComponentProps<Content.StoryHighlightSlice>;
+
+/**
+ * Component for "StoryHighlight" Slices.
+ */
+const StoryHighlight = ({ slice }: StoryHighlightProps): JSX.Element => {
+  return (
+    <section className="" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+      <PrismicRichText field={slice.primary.text} />
+    </section>
+  );
+};
+
+export default StoryHighlight;

--- a/src/slices/StoryHighlight/mocks.json
+++ b/src/slices/StoryHighlight/mocks.json
@@ -1,0 +1,20 @@
+[
+	{
+		"__TYPE__": "SharedSliceContent",
+		"variation": "default",
+		"primary": {
+			"text": {
+				"__TYPE__": "StructuredTextContent",
+				"value": [
+					{
+						"type": "paragraph",
+						"content": {
+							"text": "Lorem fugiat velit Lorem nulla sint do id magna laboris sint."
+						}
+					}
+				]
+			}
+		},
+		"items": []
+	}
+]

--- a/src/slices/StoryHighlight/model.json
+++ b/src/slices/StoryHighlight/model.json
@@ -1,0 +1,28 @@
+{
+  "id": "story_highlight",
+  "type": "SharedSlice",
+  "name": "StoryHighlight",
+  "description": "StoryHighlight",
+  "variations": [
+    {
+      "id": "default",
+      "name": "Default",
+      "docURL": "...",
+      "version": "initial",
+      "description": "Default",
+      "imageUrl": "",
+      "primary": {
+        "text": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Text",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "multi": "paragraph"
+          }
+        }
+      },
+      "items": {}
+    }
+  ]
+}

--- a/src/slices/StoryTextBlock/index.tsx
+++ b/src/slices/StoryTextBlock/index.tsx
@@ -1,0 +1,20 @@
+import { Content } from "@prismicio/client";
+import { PrismicRichText, SliceComponentProps } from "@prismicio/react";
+
+/**
+ * Props for `StoryTextBlock`.
+ */
+export type StoryTextBlockProps = SliceComponentProps<Content.StoryTextBlockSlice>;
+
+/**
+ * Component for "StoryTextBlock" Slices.
+ */
+const StoryTextBlock = ({ slice }: StoryTextBlockProps): JSX.Element => {
+  return (
+    <section className="m-auto text-black md:max-w-3xl md:text-4xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl [&>p]:mt-4 [&>p]:md:mt-6" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+      <PrismicRichText field={slice.primary.text} />
+    </section>
+  );
+};
+
+export default StoryTextBlock;

--- a/src/slices/StoryTextBlock/mocks.json
+++ b/src/slices/StoryTextBlock/mocks.json
@@ -1,0 +1,20 @@
+[
+	{
+		"__TYPE__": "SharedSliceContent",
+		"variation": "default",
+		"primary": {
+			"text": {
+				"__TYPE__": "StructuredTextContent",
+				"value": [
+					{
+						"type": "paragraph",
+						"content": {
+							"text": "Consectetur laboris enim consequat exercitation magna aliqua id id aliquip."
+						}
+					}
+				]
+			}
+		},
+		"items": []
+	}
+]

--- a/src/slices/StoryTextBlock/model.json
+++ b/src/slices/StoryTextBlock/model.json
@@ -1,0 +1,28 @@
+{
+  "id": "story_text_block",
+  "type": "SharedSlice",
+  "name": "StoryTextBlock",
+  "description": "StoryTextBlock",
+  "variations": [
+    {
+      "id": "default",
+      "name": "Default",
+      "docURL": "...",
+      "version": "initial",
+      "description": "Default",
+      "imageUrl": "",
+      "primary": {
+        "text": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Text",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "multi": "paragraph"
+          }
+        }
+      },
+      "items": {}
+    }
+  ]
+}

--- a/src/slices/StoryTextWithHeading/index.tsx
+++ b/src/slices/StoryTextWithHeading/index.tsx
@@ -1,0 +1,21 @@
+import { Content } from "@prismicio/client";
+import { PrismicRichText, SliceComponentProps } from "@prismicio/react";
+
+/**
+ * Props for `StoryTextWithHeading`.
+ */
+export type StoryTextWithHeadingProps = SliceComponentProps<Content.StoryTextWithHeadingSlice>;
+
+/**
+ * Component for "StoryTextWithHeading" Slices.
+ */
+const StoryTextWithHeading = ({ slice }: StoryTextWithHeadingProps): JSX.Element => {
+  return (
+    <section className="m-auto text-black md:max-w-3xl md:text-4xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl [&>p]:text-ex-grey [&>p]:mt-4 [&>p]:md:mt-6" data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
+      <PrismicRichText field={slice.primary.heading} />
+      <PrismicRichText field={slice.primary.text} />
+    </section>
+  );
+};
+
+export default StoryTextWithHeading;

--- a/src/slices/StoryTextWithHeading/mocks.json
+++ b/src/slices/StoryTextWithHeading/mocks.json
@@ -1,0 +1,31 @@
+[
+	{
+		"__TYPE__": "SharedSliceContent",
+		"variation": "default",
+		"primary": {
+			"heading": {
+				"__TYPE__": "StructuredTextContent",
+				"value": [
+					{
+						"type": "heading4",
+						"content": {
+							"text": "Steam"
+						}
+					}
+				]
+			},
+			"text": {
+				"__TYPE__": "StructuredTextContent",
+				"value": [
+					{
+						"type": "paragraph",
+						"content": {
+							"text": "Cupidatat in laborum sit reprehenderit laborum eiusmod commodo eiusmod aliquip."
+						}
+					}
+				]
+			}
+		},
+		"items": []
+	}
+]

--- a/src/slices/StoryTextWithHeading/model.json
+++ b/src/slices/StoryTextWithHeading/model.json
@@ -1,0 +1,37 @@
+{
+  "id": "story_text_with_heading",
+  "type": "SharedSlice",
+  "name": "StoryTextWithHeading",
+  "description": "StoryTextWithHeading",
+  "variations": [
+    {
+      "id": "default",
+      "name": "Default",
+      "docURL": "...",
+      "version": "initial",
+      "description": "Default",
+      "imageUrl": "",
+      "primary": {
+        "heading": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Heading",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "single": "heading4"
+          }
+        },
+        "text": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Text",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "multi": "paragraph"
+          }
+        }
+      },
+      "items": {}
+    }
+  ]
+}

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -7,6 +7,7 @@ export const components = {
   highlight: dynamic(() => import("./Highlight")),
   playbooks: dynamic(() => import("./Playbooks")),
   single_heading: dynamic(() => import("./SingleHeading")),
+  story_gallery: dynamic(() => import("./StoryGallery")),
   story_highlight: dynamic(() => import("./StoryHighlight")),
   story_text_block: dynamic(() => import("./StoryTextBlock")),
   story_text_with_heading: dynamic(() => import("./StoryTextWithHeading")),

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -7,6 +7,7 @@ export const components = {
   highlight: dynamic(() => import("./Highlight")),
   playbooks: dynamic(() => import("./Playbooks")),
   single_heading: dynamic(() => import("./SingleHeading")),
+  story_highlight: dynamic(() => import("./StoryHighlight")),
   text_block: dynamic(() => import("./TextBlock")),
   text_with_heading: dynamic(() => import("./TextWithHeading")),
   video_embed: dynamic(() => import("./VideoEmbed")),

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -8,6 +8,7 @@ export const components = {
   playbooks: dynamic(() => import("./Playbooks")),
   single_heading: dynamic(() => import("./SingleHeading")),
   story_gallery: dynamic(() => import("./StoryGallery")),
+  story_gems: dynamic(() => import("./StoryGems")),
   story_highlight: dynamic(() => import("./StoryHighlight")),
   story_text_block: dynamic(() => import("./StoryTextBlock")),
   story_text_with_heading: dynamic(() => import("./StoryTextWithHeading")),

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -9,6 +9,7 @@ export const components = {
   single_heading: dynamic(() => import("./SingleHeading")),
   story_highlight: dynamic(() => import("./StoryHighlight")),
   story_text_block: dynamic(() => import("./StoryTextBlock")),
+  story_text_with_heading: dynamic(() => import("./StoryTextWithHeading")),
   text_block: dynamic(() => import("./TextBlock")),
   text_with_heading: dynamic(() => import("./TextWithHeading")),
   video_embed: dynamic(() => import("./VideoEmbed")),

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -8,6 +8,7 @@ export const components = {
   playbooks: dynamic(() => import("./Playbooks")),
   single_heading: dynamic(() => import("./SingleHeading")),
   story_highlight: dynamic(() => import("./StoryHighlight")),
+  story_text_block: dynamic(() => import("./StoryTextBlock")),
   text_block: dynamic(() => import("./TextBlock")),
   text_with_heading: dynamic(() => import("./TextWithHeading")),
   video_embed: dynamic(() => import("./VideoEmbed")),


### PR DESCRIPTION
This PR adds stories page along with slices used in the story page
* StoryHighlight
* StoryTextBlock
* StoryTextWithHeading


Notes
* I leftout `Gems in this story` in the banner as most stories did not have it and from a UX perspective it does not convey what are icons and what each icon represents etc
* Right now `StoryGems` slice need to be linked to the author as i did not find a away to get the author from parent document and gems can have multiple authors unrelated to the story
* Also leftout related stories and places for now